### PR TITLE
Use XeTeX and DejaVu Sans Mono

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,8 +12,8 @@ clean :
 cefp.pdf : par.tex conc.tex
 
 lab-exercises.pdf : lab-exercises.tex
-	pdflatex $<
-	pdflatex $<
+	xelatex $<
+	xelatex $<
 
 kmeans-example.png : kmeans-example-points kmeans-example-clusters
 	gnuplot -e 'set key off; set terminal png; plot "kmeans-example-points","kmeans-example-clusters" with points pointsize 20 pointtype 6' >$@

--- a/doc/lab-exercises.tex
+++ b/doc/lab-exercises.tex
@@ -1,5 +1,7 @@
 \documentclass[11pt,a4paper]{article}
 
+\usepackage{fontspec}
+\setmonofont[Scale=0.85]{DejaVu Sans Mono}
 \usepackage{listings}
 \usepackage{color}
 \usepackage{code}

--- a/doc/par.tex
+++ b/doc/par.tex
@@ -1199,7 +1199,7 @@ here, all we need to do is express the graph in the @Par@ monad:
 
 \begin{haskell}
 do
-   [ia,ib,ic] <- replicateM 4 new
+   [ia,ib,ic] <- replicateM 3 new
 
    fork $ do x <- get input
              put ia (f x)


### PR DESCRIPTION
Use XeTeX instead of pdfLaTeX, to allow easy use of DejaVu Sans Mono monospace font, so that most of the fancy Unicode is displayed.
